### PR TITLE
Improperly rendered SOA header

### DIFF
--- a/_playbook/microservices-playbook.md
+++ b/_playbook/microservices-playbook.md
@@ -8,6 +8,6 @@ Microservices is a software architecture that is gaining rapid adoption by cloud
 
 For example, the Twitter homepage is composed through calls to dozens of microservices, including a “who to follow” microservice, a “trends” microservice, a “tweets” microservice, and many others -- some of which in turn call other microservices. The key to a successful microservices architecture is the loose coupling, which enables each microservice to be developed, tested, and released independently of the other microservices.
 
-###Isn’t this just SOA?
+### Isn’t this just SOA?
 
 Many people frequently point out that the core concepts of microservices were pioneered in service oriented architectures (SOA). While there are some technical similarities between microservices and SOA, microservices is focused on a different class of problems -- how to organizationally and computationally scale your cloud-native application architecture -- and takes advantage of cloud and DevOps technologies to create a more powerful, flexible approach to software architecture for cloud-native applications.


### PR DESCRIPTION
The rendered header currently looks like:

<img width="254" alt="screen shot 2016-02-11 at 12 04 07 pm" src="https://cloud.githubusercontent.com/assets/2181356/12988860/9953fc2e-d0b7-11e5-979f-9d7ec8f07bae.png">

With this change, the header should render properly.
